### PR TITLE
round blocksync percentage down

### DIFF
--- a/react/src/components/postAuth/apps/wallet/coinWallet/coinWallet.js
+++ b/react/src/components/postAuth/apps/wallet/coinWallet/coinWallet.js
@@ -260,7 +260,7 @@ class CoinWallet extends React.Component {
           
           if (info) {
             const { connections, longestchain, blocks } = info
-            const percentage = longestchain < blocks ? 0 : Number(((blocks / longestchain) * 100).toFixed(2))
+            const percentage = longestchain < blocks ? 0 : Math.floor((blocks / longestchain) * 10000) / 100
             
 
             walletLoadState = {


### PR DESCRIPTION
Most users do not look at the message behind the percentage in the GUI.
Currently the dial shows 100% when the sync percentage exceeds 99.995 percent, leading users to think they are fully in sync.
Rounding down to two decimals will show 99.99%, until the local chain is actually in sync.